### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/__unused__/identity-access-manager-keycloak/docker-compose-postgres.cluster.yml
+++ b/__unused__/identity-access-manager-keycloak/docker-compose-postgres.cluster.yml
@@ -10,7 +10,7 @@ services:
           - "node.labels.name==node-1"
 
   keycloak-postgres-2:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     environment:
       POSTGRESQL_PASSWORD: ${KC_POSTGRESQL_PASSWORD}
       POSTGRESQL_USERNAME: ${KC_POSTGRESQL_USERNAME}
@@ -41,7 +41,7 @@ services:
 
 
   keycloak-postgres-3:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     environment:
       POSTGRESQL_PASSWORD: ${KC_POSTGRESQL_PASSWORD}
       POSTGRESQL_USERNAME: ${KC_POSTGRESQL_USERNAME}

--- a/__unused__/identity-access-manager-keycloak/docker-compose-postgres.yml
+++ b/__unused__/identity-access-manager-keycloak/docker-compose-postgres.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   keycloak-postgres-1:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     environment:
       POSTGRESQL_PASSWORD: ${KC_POSTGRESQL_PASSWORD}
       POSTGRESQL_USERNAME: ${KC_POSTGRESQL_USERNAME}

--- a/packages/client-registry-opencr/docker-compose-postgres.cluster.yml
+++ b/packages/client-registry-opencr/docker-compose-postgres.cluster.yml
@@ -42,7 +42,7 @@ services:
 
 
   opencr-postgres-3:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     environment:
       POSTGRESQL_PASSWORD: ${OPENCR_HF_POSTGRESQL_PASSWORD}
       POSTGRESQL_USERNAME: ${OPENCR_HF_POSTGRESQL_USERNAME}


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/postgresql-repmgr:14` → [`soldevelo/postgresql-repmgr:14`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)